### PR TITLE
Update feature detection to use target_has_atomic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ mutex = ['crossbeam-utils']
 [dependencies.crossbeam-utils]
 version = '0.8'
 optional = true
-[target."cfg(target_has_atomic=\"64\"))".dependencies]
+[target."cfg(target_has_atomic=\"64\")".dependencies]
 crossbeam-utils = '0.8'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = 'https://github.com/bltavares/atomic-shim'
 readme = 'README.md'
 license = 'MIT OR Apache-2.0'
 keywords = ['atomic']
+rust-version = "1.60"
 [package.metadata.docs.rs]
 features = ['mutex']
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,5 @@ mutex = ['crossbeam-utils']
 [dependencies.crossbeam-utils]
 version = '0.8'
 optional = true
-[target."cfg(target_arch = \"mips\")".dependencies]
-crossbeam-utils = '0.8'
-[target."cfg(target_arch = \"powerpc\")".dependencies]
+[target."cfg(target_has_atomic=\"64\"))".dependencies]
 crossbeam-utils = '0.8'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,11 +52,11 @@
 //! println!("live threads: {}", old_thread_count + 1);
 //! ```
 
-#[cfg(not(any(target_arch = "mips", target_arch = "powerpc", feature = "mutex")))]
+#[cfg(target_has_atomic="64")]
 pub use std::sync::atomic::{AtomicI64, AtomicU64};
 
-#[cfg(any(target_arch = "mips", target_arch = "powerpc", feature = "mutex"))]
+#[cfg(target_has_atomic="64")]
 mod shim;
 
-#[cfg(any(target_arch = "mips", target_arch = "powerpc", feature = "mutex"))]
+#[cfg(target_has_atomic="64")]
 pub use shim::{AtomicI64, AtomicU64};


### PR DESCRIPTION
Rust 1.60 stabilized the `target_has_atomic` cfg, adopt it to use the shim on all platforms that require it (e.g. armv5te and more). Fixes #4.